### PR TITLE
refactor: replace deprecated json function with fromJson

### DIFF
--- a/src/main/java/io/kestra/plugin/couchbase/Trigger.java
+++ b/src/main/java/io/kestra/plugin/couchbase/Trigger.java
@@ -45,7 +45,7 @@ import lombok.experimental.SuperBuilder;
                     tasks:
                       - id: return
                         type: io.kestra.plugin.core.debug.Return
-                        format: "{{ json(taskrun.value) }}"
+                        format: "{{ fromJson(taskrun.value) }}"
 
                 triggers:
                   - id: watch


### PR DESCRIPTION
Updates the deprecated json function to fromJson, which exists in 1.x