### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/couchbase/CouchbaseConnection.java
+++ b/src/main/java/io/kestra/plugin/couchbase/CouchbaseConnection.java
@@ -8,6 +8,8 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
 
+import io.kestra.core.models.annotations.PluginProperty;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
@@ -28,10 +30,13 @@ public abstract class CouchbaseConnection extends Task implements CouchbaseConne
 
     @NotNull
     @NotBlank
+    @PluginProperty(secret = true, dynamic = true, group = "connection")
     protected String username;
 
     @NotNull
     @NotBlank
+    @ToString.Exclude
+    @PluginProperty(secret = true, dynamic = true, group = "connection")
     protected String password;
 
     protected Cluster connect(RunContext runContext) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/couchbase/Trigger.java
+++ b/src/main/java/io/kestra/plugin/couchbase/Trigger.java
@@ -9,6 +9,7 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.models.triggers.*;
@@ -67,10 +68,13 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
 
     @NotNull
     @NotBlank
+    @PluginProperty(secret = true, dynamic = true, group = "connection")
     protected String username;
 
     @NotNull
     @NotBlank
+    @ToString.Exclude
+    @PluginProperty(secret = true, dynamic = true, group = "connection")
     protected String password;
 
     @NotNull


### PR DESCRIPTION
## Summary

Remediates all findings from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **[HIGH]** @ToString exposes password in plaintext on CouchbaseConnection (`src/main/java/io/kestra/plugin/couchbase/CouchbaseConnection.java:20`)
  - Fix: Added `@ToString.Exclude` to the `password` field to prevent Lombok from including it in the generated `toString()` output.

- **[HIGH]** @ToString exposes password in plaintext on Trigger (`src/main/java/io/kestra/plugin/couchbase/Trigger.java:24`)
  - Fix: Added `@ToString.Exclude` to the `password` field in Trigger to prevent plaintext password exposure in logs and serialized state.

- **[MEDIUM]** Missing @PluginProperty(secret=true) on concrete password fields — interface annotation not inherited by Lombok-generated getters (`src/main/java/io/kestra/plugin/couchbase/CouchbaseConnectionInterface.java:26`)
  - Fix: Added `@PluginProperty(secret = true, dynamic = true, group = "connection")` directly to the `username` and `password` field declarations in both `CouchbaseConnection` and `Trigger`, ensuring Lombok-generated getters carry the annotation on the concrete class so Kestra's plugin property scanner masks these values correctly.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests
- [ ] Manually verified the patched code paths

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-couchbase/issues/119
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)

---
*Automated security fix — please review each change carefully before merging.*
