### PR TITLE
docs(couchbase): fix trigger example query, add subgroup title and how-to heading

### DIFF
--- a/src/main/java/io/kestra/plugin/couchbase/Trigger.java
+++ b/src/main/java/io/kestra/plugin/couchbase/Trigger.java
@@ -55,7 +55,7 @@ import lombok.experimental.SuperBuilder;
                     connectionString: couchbase://localhost
                     username: couchbase_user
                     password: "{{ secret('COUCHBASE_PASSWORD') }}"
-                    query: SELECT * FROM `COUCHBASE_BUCKET`(.`COUCHBASE_SCOPE`.`COUCHBASE_COLLECTION`)
+                    query: SELECT * FROM `COUCHBASE_BUCKET`.`COUCHBASE_SCOPE`.`COUCHBASE_COLLECTION`
                     fetchType: FETCH
                 """
         )

--- a/src/main/java/io/kestra/plugin/couchbase/package-info.java
+++ b/src/main/java/io/kestra/plugin/couchbase/package-info.java
@@ -1,4 +1,5 @@
 @PluginSubGroup(
+    title = "Couchbase",
     description = "This sub-group of plugins contains tasks for using Couchbase.\n" +
         "Couchbase is an award-winning distributed NoSQL cloud database that delivers unmatched versatility, performance, scalability, and financial value for all of your cloud, mobile, on-premises, hybrid, distributed cloud, and edge computing applications.",
     categories = {

--- a/src/main/resources/doc/io.kestra.plugin.couchbase.md
+++ b/src/main/resources/doc/io.kestra.plugin.couchbase.md
@@ -1,3 +1,5 @@
+# How to use the Couchbase plugin
+
 This plugin runs N1QL queries against a Couchbase cluster and lets a flow react to query results.
 
 ## Tasks
@@ -5,7 +7,7 @@ This plugin runs N1QL queries against a Couchbase cluster and lets a flow react 
 - `Query` executes a N1QL statement and captures the result. Set `fetchType` to:
   - `FETCH` to return all rows inline in the task output,
   - `FETCH_ONE` to return only the first row,
-  - `STORE` to write the full result set to Kestra internal storage as an ion file.
+  - `STORE` to write the full result set to Kestra internal storage as an ION file.
 
 ## Triggers
 


### PR DESCRIPTION
## Documentation review: plugin-couchbase

Task-level doc pass over the two tasks (`Query`, `Trigger`), the shared connection/query interfaces, `index.yaml`, and the how-to doc. Documentation only; no runtime behavior changes.

### Fixes
- **`Trigger` example** — the N1QL query ``SELECT * FROM `COUCHBASE_BUCKET`(.`COUCHBASE_SCOPE`.`COUCHBASE_COLLECTION`)`` is not valid N1QL (the `(.…)` parenthetical with a leading dot). Replaced with a valid fully-qualified `` `COUCHBASE_BUCKET`.`COUCHBASE_SCOPE`.`COUCHBASE_COLLECTION` `` (the `Query` example already uses a clean `SELECT * FROM \`COUCHBASE_BUCKET\``).
- **`package-info.java`** — `@PluginSubGroup` was missing the `title` attribute → added `"Couchbase"` (matches `index.yaml`).
- **how-to doc** — added the missing `# How to use the Couchbase plugin` H1 heading (the file began mid-sentence), and "as an ion file" → "ION file".

`Query`/`Trigger` titles, descriptions, the `Query` example, output `@Schema`, `username`/`password` `secret = true`, `index.yaml`, and the how-to Tasks/Triggers/Connection content were otherwise accurate.

---

## 🚩 Engineering flags (not addressed here — code changes)
- **`Query` STORE branch double-writes** — in `run()` the `STORE` case writes every row individually via `FileSerde.write(outputStream, row)` in the `forEach`, then also writes the entire `rowsAsMap` list once more (`FileSerde.write(outputStream, rowsAsMap)`), so the ION file ends with a duplicate record containing all rows. Also the `BufferedWriter fileWriter` is created (and flushed/closed) but never written to — dead code. Remove the trailing list write and the unused writer.
- **`connectionString` is marked `@PluginProperty(secret = true)`** (in `CouchbaseConnectionInterface.getConnectionString`). A Couchbase connection string like `couchbase://host` is a host address, not a credential; masking it is unusual — confirm intentional or drop `secret = true`.
- **Field-vs-interface group mismatches** — `Query.parameters` is `group = "main"` while `QueryInterface.getParameters` is `group = "advanced"`; `Query.fetchType` is `group = "processing"` while `QueryInterface.getFetchType` is `group = "execution"`. Reconcile so the rendered grouping is consistent.